### PR TITLE
Fix: Type errors in expense and document services

### DIFF
--- a/src/documents/dto/document-filters.dto.ts
+++ b/src/documents/dto/document-filters.dto.ts
@@ -73,9 +73,5 @@ export class DocumentQueryDto extends PaginationDto {
 
   @IsOptional()
   @IsString()
-  accountId?: string
-
-  @IsOptional()
-  @IsString()
   costCenterId?: string
 }

--- a/src/documents/dto/document-response.dto.ts
+++ b/src/documents/dto/document-response.dto.ts
@@ -1,17 +1,6 @@
 import { DocumentType, DocumentStatus } from "@prisma/client"
 
-export class DocumentLineAccountLinkResponseDto {
-  id: string
-  accountId: string
-  percentage: number
-  amount: number
-  createdAt: Date
-  account?: {
-    id: string
-    accountCode: string
-    accountName: string
-  }
-}
+// Removed DocumentLineAccountLinkResponseDto
 
 export class DocumentLineCostCenterLinkResponseDto {
   id: string
@@ -56,7 +45,7 @@ export class DocumentLineResponseDto {
   xmlLineData?: string
   createdAt: Date
   updatedAt: Date
-  accountLinks?: DocumentLineAccountLinkResponseDto[]
+  // accountLinks?: DocumentLineAccountLinkResponseDto[] // Removed
   costCenterLinks?: DocumentLineCostCenterLinkResponseDto[]
 }
 
@@ -70,18 +59,7 @@ export class DocumentPaymentTermResponseDto {
   updatedAt: Date
 }
 
-export class DocumentAccountLinkResponseDto {
-  id: string
-  accountId: string
-  percentage: number
-  amount: number
-  createdAt: Date
-  account?: {
-    id: string
-    accountCode: string
-    accountName: string
-  }
-}
+// Removed DocumentAccountLinkResponseDto
 
 export class DocumentCostCenterLinkResponseDto {
   id: string
@@ -198,7 +176,7 @@ export class DocumentResponseDto {
 
   lines?: DocumentLineResponseDto[]
   paymentTerms?: DocumentPaymentTermResponseDto[]
-  accountLinks?: DocumentAccountLinkResponseDto[]
+  // accountLinks?: DocumentAccountLinkResponseDto[] // Removed
   costCenterLinks?: DocumentCostCenterLinkResponseDto[]
   xmlData?: DocumentXmlDataResponseDto
   digitalSignature?: DocumentDigitalSignatureResponseDto

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -51,15 +51,19 @@ export class ExpensesService {
 
   async createExpense(expenseDto: CreateExpenseDto): Promise<Expense> { // Changed 'any' to CreateExpenseDto
     this.logger.log(`Creating expense for company ${expenseDto.companyId}`);
+    // Destructure to remove currency if it's causing issues, assuming currencyId might be in expenseDto
+    const { currency, ...restOfExpenseDto } = expenseDto;
+
     const expenseData = {
-      ...expenseDto,
-      transactionDate: new Date(expenseDto.transactionDate), // Ensure date conversion
+      ...restOfExpenseDto, // Spread the rest of the DTO
+      transactionDate: new Date(expenseDto.transactionDate), // Ensure date conversion (use original expenseDto for safety here)
       valueDate: expenseDto.valueDate ? new Date(expenseDto.valueDate) : null,
       documentDate: expenseDto.documentDate ? new Date(expenseDto.documentDate) : null,
       issueDate: expenseDto.issueDate ? new Date(expenseDto.issueDate) : null,
       dueDate: expenseDto.dueDate ? new Date(expenseDto.dueDate) : null,
       status: expenseDto.status || ExpenseStatus.IMPORTED,
       // Ensure other fields like rowHash, importedAt are handled correctly if part of DTO or set by default
+      // If currencyId is in expenseDto, it will be included via ...restOfExpenseDto
     };
 
     try {


### PR DESCRIPTION
- Expense Service: Resolved Prisma type error in createExpense related to 'currency' field.
- Document Service & DTOs:
  - Replaced DocumentFiltersDto with DocumentQueryDto.
  - Removed 'Account' model and related 'accountLinks' functionality (fields, types, logic) from document service and DTOs as per user instruction, resolving associated type errors and line-specific errors.